### PR TITLE
restoring old (global) coverage calculation

### DIFF
--- a/bioy_pkg/subcommands/blast.py
+++ b/bioy_pkg/subcommands/blast.py
@@ -166,12 +166,14 @@ def action(args):
     # make into dict
     lines = [dict(l) for l in lines]
 
-    if isinstance(args.coverage, float):
+    # Replace blast's local alignment query coverage with global coverage calculation
+    if 'qcovs' in args.outfmt.split(',') or isinstance(args.coverage, float):
         for l in lines:
-            l['coverage'] = (float(l['qend']) - float(l['qstart']) + 1) \
+            l['qcovs'] = (float(l['qend']) - float(l['qstart']) + 1) \
                     / float(l['qlen']) * 100
-            l['coverage'] = '{0:.2f}'.format(l['coverage'])
-        lines = [l for l in lines if float(l['coverage']) >= args.coverage]
+            l['qcovs'] = '{0:.2f}'.format(l['qcovs'])
+    if isinstance(args.coverage, float):
+        lines = [l for l in lines if float(l['qcovs']) >= args.coverage]
 
     if args.nohits:
         # to get nohits first we need to know about the hits

--- a/bioy_pkg/subcommands/blast.py
+++ b/bioy_pkg/subcommands/blast.py
@@ -166,8 +166,12 @@ def action(args):
     # make into dict
     lines = [dict(l) for l in lines]
 
-    if isinstance(args.coverage, float) and 'qcovs' in args.outfmt.split(','):
-        lines = [l for l in lines if float(l['qcovs']) >= args.coverage]
+    if isinstance(args.coverage, float):
+        for l in lines:
+            l['coverage'] = (float(l['qend']) - float(l['qstart']) + 1) \
+                    / float(l['qlen']) * 100
+            l['coverage'] = '{0:.2f}'.format(l['coverage'])
+        lines = [l for l in lines if float(l['coverage']) >= args.coverage]
 
     if args.nohits:
         # to get nohits first we need to know about the hits


### PR DESCRIPTION
Restore old coverage calculation.

Notes:

* This leaves "qcovs", as provided by blast, unchanged
* If args.coverage is provided, this calculates coverage internally and filters lines that don't meet the threshold.  The internally calculated coverage isn't reported.  This approach seems less disingenuous than clobbering blast's "qocvs" field.
* I opted to leave fields "qstart", "qend", "qlen" as implicit requirements so the code will fail noisily if they are omitted.  Should we mention this in the argparse help text?