### PR TITLE
41 hits below threshold

### DIFF
--- a/bioy_pkg/subcommands/classifier.py
+++ b/bioy_pkg/subcommands/classifier.py
@@ -902,8 +902,7 @@ def action(args):
         if args.hits_below_threshold:
             with args.hits_below_threshold as hits_below_threshold:
                 below_threshold_columns = ['specimen','tax_name','rank','tax_id',
-                                           'tax_name','pident','qcovs','qseqid',
-                                           'accession','sseqid']
+                                           'pident','qcovs','qseqid', 'accession','sseqid']
                 below_threshold.to_csv(
                     hits_below_threshold,
                     columns=below_threshold_columns,

--- a/bioy_pkg/subcommands/classifier.py
+++ b/bioy_pkg/subcommands/classifier.py
@@ -195,7 +195,6 @@ log = logging.getLogger(__name__)
 
 ASSIGNMENT_TAX_ID = 'assignment_tax_id'
 
-
 def raw_filtering(blast_results, min_coverage=None,
                   max_identity=None, min_identity=None):
     """run raw hi, low and coverage filters and output log information
@@ -525,6 +524,10 @@ def build_parser(parser):
     parser.add_argument(
         '-O', '--details-out', type=Opener('w'), metavar='FILE',
         help="""Optional details of taxonomic assignments.""")
+    parser.add_argument(
+        '--hits-below-threshold', type=Opener('w'), metavar='FILE',
+        help="""Hits that were below the best-rank threshold and not used for
+        classification""")
 
     # switches and options
     parser.add_argument(
@@ -697,6 +700,7 @@ def action(args):
     # assign assignment tax ids based on pident and thresholds
     blast_results_len = float(len(blast_results))
     blast_results = blast_results.sort('qseqid').reset_index(drop=True)
+    results_belowthreshold = blast_results
     blast_results = blast_results.groupby(
         by=['specimen', 'qseqid'], group_keys=False)
     blast_results = blast_results.apply(
@@ -768,6 +772,7 @@ def action(args):
             assign, tax_dict, blast_results_len)
         sys.stderr.write('\n')
 
+
     # merge qseqids that have no hits back into blast_results
     blast_results = blast_results.merge(qseqids, how='outer')
 
@@ -775,6 +780,11 @@ def action(args):
     no_hits = blast_results['sseqid'].isnull()
     blast_results.loc[no_hits, 'assignment'] = '[no blast result]'
     blast_results.loc[no_hits, 'assignment_hash'] = 0
+
+    # merge back in blast hits that were filtered because they were below threshold
+    if args.hits_below_threshold:
+        everything = blast_results.merge(results_belowthreshold, how='outer',)[blast_results.columns]
+        below_threshold = everything[~everything['accession'].isin(blast_results['accession'])]
 
     # concludes our blast details, on to output summary
     log.info('summarizing output')
@@ -856,6 +866,7 @@ def action(args):
 
     # output to details.csv.bz2
     if args.details_out:
+        # Annotate details with classification columns
         blast_results = blast_results.merge(output.reset_index(), how='left')
 
         if not args.details_full:
@@ -887,3 +898,15 @@ def action(args):
                 header=True,
                 index=False,
                 float_format='%.2f')
+
+        if args.hits_below_threshold:
+            with args.hits_below_threshold as hits_below_threshold:
+                below_threshold_columns = ['specimen','tax_name','rank','tax_id',
+                                           'tax_name','pident','qcovs','qseqid',
+                                           'accession','sseqid']
+                below_threshold.to_csv(
+                    hits_below_threshold,
+                    columns=below_threshold_columns,
+                    header=True,
+                    index=False,
+                    float_format='%.2f')


### PR DESCRIPTION
Added a new argument that can optionally include hits that would otherwise be thrown out because they were below the best rank threshold.

I've included some notes describing what it looks like the classifier is doing and where I've made changes, in an effort to avoid a careless mistake:

Blast results get filtered several times
* if specimen map given, filter hits with unrepresented qseqid
* "raw_filtering", -- filter on coverage, min/max identity
* remove no_blast_results  ... (hits with no sseqid) ... (added back in later)
* discard blast hits whose sseqids aren't in seq_info
* filter results not in taxonomy, add "tax_name", "rank" columns
* "join_thresholds" -- adds "threshold" columns for every rank, if applicable
* **save current blast hits as results_belowthreshold; we will be sidestepping subsequent filtering steps and outputting filtered hits to a separate file** *
* select_valid_blast_hits ... throws away sub-optimal rank hits
...
* drop unnecessary columns
* rename columns (tax_name_assignment, rank_assignment)
* "condense assignment hashes"
* "condense_ids"
* Add "rank_condensed" column, selecting the taxonomic rank for "condensed_id" taxid
* Add "star" column if one hit is 100%
* "assign" ... I think this is for classification name
* Add back no_blast_results ("qseqids")
* **blast_results is done being filtered; determine which hits have been filtered and save them to a separate data frame to be output to a separate file**